### PR TITLE
feat: inject secret store csi driver

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,8 @@ toc::[]
 * Deploy your application containers on to Kubernetes
 * Zero-downtime rolling deployments
 * Auto scaling and auto healing
-* Configuration management and Secrets management
+* Configuration management and Secrets management 
+** Secrets as Environment/Volumes/Secret Store CSI
 * Ingress and Service endpoints
 
 

--- a/charts/k8s-service/README.md
+++ b/charts/k8s-service/README.md
@@ -896,12 +896,34 @@ secrets:
         filePath: password
 ```
 
+**Mounting secrets with CSI**: In this example, we mount the `my-secret` `Secret` as the file `/etc/db`, and specify that the secret will sync with Secret Manager store (AWS, GCP, Vault) secret named `my-secret`. We also details the csi block were we define the driver and secreteProviderClass.
+
+```yaml
+secrets:
+  my-secret:
+    as: csi
+    mountPath: /etc/db
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: secret-provider-class
+    items:
+      - name: ENV_1
+        valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: ENV_1
+```
+
 **NOTE**: The volumes are different between `secrets` and `configMaps`. This means that if you use the same `mountPath`
 for different secrets and config maps, you can end up with only one. It is undefined which `Secret` or `ConfigMap` ends
 up getting mounted. To be safe, use a different `mountPath` for each one.
 
 **NOTE**: If you want mount the volumes created with `secrets` or `configMaps` on your init or sidecar containers, you will 
 have to append `-volume` to the volume name in . In the example above, the resulting volume will be `my-secret-volume`.
+
+**Note** When installing the CSI driver on your cluster you have an option to activate syncing of secrets 
 
 ```yaml
 sideCarContainers:

--- a/charts/k8s-service/templates/_deployment_spec.tpl
+++ b/charts/k8s-service/templates/_deployment_spec.tpl
@@ -21,7 +21,7 @@ We need this because certain sections are omitted if there are no volumes or env
 */ -}}
 
 {{/* Go Templates do not support variable updating, so we simulate it using dictionaries */}}
-{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "exposePorts" false -}}
+{{- $hasInjectionTypes := dict "hasVolume" false "hasEnvVars" false "hasSecretStoreVars" false  "exposePorts" false -}}
 {{- if .Values.envVars -}}
   {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
 {{- end -}}
@@ -43,6 +43,9 @@ We need this because certain sections are omitted if there are no volumes or env
     {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
   {{- else if eq (index . "as") "environment" -}}
     {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}
+  {{- else if eq (index . "as") "csi" -}}
+    {{- $_ := set $hasInjectionTypes "hasEnvVars" true -}}    
+    {{- $_ := set $hasInjectionTypes "hasVolume" true -}}
   {{- else if eq (index . "as") "envFrom" }}
     {{- $_ := set $hasInjectionTypes "hasEnvFrom" true -}}
   {{- else if eq (index . "as") "none" -}}
@@ -290,6 +293,15 @@ spec:
                   key: {{ $secretKey }}
             {{- end }}
             {{- end }}
+            {{- if eq $value.as "csi" }}
+            {{- range $secretName, $keyEnvVarConfig := $value.items }}
+            - name: {{ required "envVarName is required on secrets items when using environment" $keyEnvVarConfig.name | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $name }}
+                  key: {{ $keyEnvVarConfig.name }}
+            {{- end }}
+            {{- end }}
           {{- end }}
           {{- if index $hasInjectionTypes "hasEnvFrom" }}
           envFrom:
@@ -323,7 +335,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- range $name, $value := .Values.secrets }}
-            {{- if eq $value.as "volume" }}
+            {{- if ne $value.as "environemnt" }}
             - name: {{ $name }}-volume
               mountPath: {{ quote $value.mountPath }}
               {{- if $value.subPath }}
@@ -392,12 +404,13 @@ spec:
                 mode: {{ include "k8s-service.fileModeOctalToDecimal" $keyMountConfig.fileMode }}
                 {{- end }}
               {{- end }}
-            {{- end }}
+            {{- end }}        
       {{- end }}
     {{- end }}
     {{- range $name, $value := .Values.secrets }}
       {{- if eq $value.as "volume" }}
         - name: {{ $name }}-volume
+         
           secret:
             secretName: {{ $name }}
             {{- if $value.items }}
@@ -411,6 +424,15 @@ spec:
               {{- end }}
             {{- end }}
       {{- end }}
+      {{- if eq $value.as "csi" }}
+        - name: {{ $name }}-volume          
+          csi: 
+            readOnly: {{ $value.csi.readOnly }}
+            driver:  {{ $value.csi.driver }}
+            volumeAttributes:
+              secretProviderClass: {{ $value.csi.volumeAttributes.secretProviderClass }}
+          
+      {{- end }}    
     {{- end }}
     {{- range $name, $value := .Values.persistentVolumes }}
         - name: {{ $name }}

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -23,12 +23,20 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 	deployment := renderK8SServiceDeploymentWithSetValues(
 		t,
 		map[string]string{
-			"secrets.dbsettings.as":           "volume",
+			"serviceAccount.name":	           "secret-sa",
+			"secrets.dbsettings.as":           "csi",
 			"secrets.dbsettings.mountPath":    "/etc/db",
 			"secrets.dbsettings.csi.driver":   "secrets-store.csi.k8s.io",
 			"secrets.dbsettings.csi.readOnly": "true",
 
-			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "backend-deployment-aws-secrets",
+			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "secret-provider-class",
+
+			"secrets.dbsettings.items[0].name": "ENV_1",
+			"secrets.dbsettings.items[0].valueFrom.secretKeyRef.name": "dbsettings",
+			"secrets.dbsettings.items[0].valueFrom.secretKeyRef.key": "ENV_1",
+			"secrets.dbsettings.items[1].name": "ENV_2",
+			"secrets.dbsettings.items[1].valueFrom.secretKeyRef.name": "dbsettings",
+			"secrets.dbsettings.items[1].valueFrom.secretKeyRef.key": "ENV_2",
 		},
 	)
 
@@ -42,8 +50,7 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 
 	// Check that the pod volume is a secret volume
 	assert.Equal(t, podVolume.Name, "dbsettings-volume")
-	require.NotNil(t, podVolume.Secret)
-	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")
+
 
 	// Check that the pod volume has CSI block
 	require.NotNil(t, podVolume.CSI)
@@ -51,7 +58,7 @@ func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
 	assert.Equal(t, podVolume.CSI.Driver, "secrets-store.csi.k8s.io")
 	assert.NotNil(t, podVolume.CSI.VolumeAttributes)
 	assert.Equal(t, podVolume.CSI.VolumeAttributes, map[string]string{
-		"secretProviderClass": "backend-deployment-aws-secrets",
+		"secretProviderClass": "secret-provider-class",
 	})
 
 }

--- a/test/k8s_service_volume_secret_store_csi_template_test.go
+++ b/test/k8s_service_volume_secret_store_csi_template_test.go
@@ -1,0 +1,57 @@
+//go:build all || tpl
+// +build all tpl
+
+// NOTE: We use build flags to differentiate between template tests and integration tests so that you can conveniently
+// run just the template tests. See the test README for more information.
+
+package test
+
+import (
+	// "fmt"
+	// "github.com/gruntwork-io/terratest/modules/random"
+
+	// "github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	// "strings"
+	"testing"
+)
+
+func TestK8SServiceDeploymentCheckSecretStoreCSIBlock(t *testing.T) {
+	t.Parallel()
+
+	deployment := renderK8SServiceDeploymentWithSetValues(
+		t,
+		map[string]string{
+			"secrets.dbsettings.as":           "volume",
+			"secrets.dbsettings.mountPath":    "/etc/db",
+			"secrets.dbsettings.csi.driver":   "secrets-store.csi.k8s.io",
+			"secrets.dbsettings.csi.readOnly": "true",
+
+			"secrets.dbsettings.csi.volumeAttributes.secretProviderClass": "backend-deployment-aws-secrets",
+		},
+	)
+
+	// Verify that there is only one container and only one volume
+	renderedPodContainers := deployment.Spec.Template.Spec.Containers
+	require.Equal(t, len(renderedPodContainers), 1)
+	// appContainer := renderedPodContainers[0]
+	renderedPodVolumes := deployment.Spec.Template.Spec.Volumes
+	require.Equal(t, len(renderedPodVolumes), 1)
+	podVolume := renderedPodVolumes[0]
+
+	// Check that the pod volume is a secret volume
+	assert.Equal(t, podVolume.Name, "dbsettings-volume")
+	require.NotNil(t, podVolume.Secret)
+	assert.Equal(t, podVolume.Secret.SecretName, "dbsettings")
+
+	// Check that the pod volume has CSI block
+	require.NotNil(t, podVolume.CSI)
+
+	assert.Equal(t, podVolume.CSI.Driver, "secrets-store.csi.k8s.io")
+	assert.NotNil(t, podVolume.CSI.VolumeAttributes)
+	assert.Equal(t, podVolume.CSI.VolumeAttributes, map[string]string{
+		"secretProviderClass": "backend-deployment-aws-secrets",
+	})
+
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

[Fixes #118.](https://github.com/gruntwork-io/helm-kubernetes-services/issues/118)

In the  `deployment_spec.tpl` we must allow a new `as` value to be passed to a secret block, we call this new type "csi".

Receiving this type of secret has to mix functionality of both volumes and environment as we will require a env block and a volumeMounts

## Steps

- [x] add template test - to check a csi block is passed to the secret
- [x] modify deployment_spec.tpl so that it can accept  "csi" for the values of the "as"  and test the template builds appropriately 
- [ ] add test for csi secret store - that the nginx is built correctly (have to install the helm charts for the secret store)
- [x] find secret related documentation to add details of how this works and how to test it


## TODOs

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes.

## Release Notes (draft)

Allow secrets to be of type CSI allowing the  injection of Secret Store CSI driver configuration to the deployment

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
